### PR TITLE
Fix data-num on "Add to cart" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,7 +1063,7 @@
                                 <div class="product_price"></div>
                                 <div style="display: none;" class="shipping_zone"></span></div>
                                 <button class="view_product_btn">View product</button>
-                                <button class="add_to_cart" data-num="${internal_products.length - 1}">Add to cart</button>
+                                <button class="add_to_cart" data-num="${i}">Add to cart</button>
                             </div>
                         `;
                         $( '.store_products' ).innerHTML += html;


### PR DESCRIPTION
On store listing, all products add its "Add to cart" button with `data-num = internal_products.length - 1,` which I think was an error, since this `data-num` value is later used to find the product in the `internal_products` array. Previous to this PR, all products in the store would have the same `data-num`.